### PR TITLE
IOS-7025 Safeguard to prevent crash when loading or removing invalid index paths.

### DIFF
--- a/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
@@ -105,7 +105,7 @@ static NSString * const kCollectionViewAdPlacerReuseIdentifier = @"MPCollectionV
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didLoadAdAtIndexPath:(NSIndexPath *)indexPath
 {
     NSInteger numberOfItemsInSection = [self.collectionView numberOfItemsInSection:indexPath.section];
-    if (indexPath.section >= [self.collectionView numberOfSections] ||
+    if (indexPath.section >= self.collectionView.numberOfSections ||
         indexPath.item >= numberOfItemsInSection) {
         NSLog(@"mopub-ios-sdk: MPCollectionViewAdPlacer: adPlacer:didLoadAdAtIndexPath: Attempted to insert item %@ in section %@ when number of sections is %@ and number of items in section is %@", @(indexPath.item), @(indexPath.section), @(self.collectionView.numberOfSections), @(numberOfItemsInSection));
         return;

--- a/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
@@ -104,6 +104,12 @@ static NSString * const kCollectionViewAdPlacerReuseIdentifier = @"MPCollectionV
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didLoadAdAtIndexPath:(NSIndexPath *)indexPath
 {
+    NSInteger numberOfItemsInSection = [self.collectionView numberOfItemsInSection:indexPath.section];
+    if (indexPath.section >= [self.collectionView numberOfSections] ||
+        indexPath.item >= numberOfItemsInSection) {
+        NSLog(@"mopub-ios-sdk: MPCollectionViewAdPlacer: adPlacer:didLoadAdAtIndexPath: Attempted to insert item %@ in section %@ when number of sections is %@ and number of items in section is %@", @(indexPath.item), @(indexPath.section), @(self.collectionView.numberOfSections), @(numberOfItemsInSection));
+        return;
+    }
     BOOL animationsWereEnabled = [UIView areAnimationsEnabled];
     //We only want to enable animations if the index path is before or within our visible cells
     BOOL animationsEnabled = ([(NSIndexPath *)[self.collectionView.indexPathsForVisibleItems lastObject] compare:indexPath] != NSOrderedAscending) && animationsWereEnabled;
@@ -117,6 +123,19 @@ static NSString * const kCollectionViewAdPlacerReuseIdentifier = @"MPCollectionV
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didRemoveAdsAtIndexPaths:(NSArray *)indexPaths
 {
+    for (const id obj in indexPaths) {
+        if (![obj isKindOfClass:[NSIndexPath class]]) {
+            return;
+        }
+        NSIndexPath *indexPath = obj;
+        NSInteger numberOfItemsInSection = [self.collectionView numberOfItemsInSection:indexPath.section];
+        if (indexPath.section >= self.collectionView.numberOfSections ||
+            indexPath.item >= numberOfItemsInSection) {
+            NSLog(@"mopub-ios-sdk: MPCollectionViewAdPlacer: adPlacer:didRemoveAdsAtIndexPath: IndexPaths: %@ Attempted to delete item %@ in section %@ when number of sections is %@ and number of items in section is %@", indexPaths, @(indexPath.item), @(indexPath.section), @(self.collectionView.numberOfSections), @(numberOfItemsInSection));
+            return;
+        }
+    }
+    
     BOOL animationsWereEnabled = [UIView areAnimationsEnabled];
     [UIView setAnimationsEnabled:NO];
 

--- a/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
@@ -104,6 +104,12 @@ static NSString * const kTableViewAdPlacerReuseIdentifier = @"MPTableViewAdPlace
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didLoadAdAtIndexPath:(NSIndexPath *)indexPath
 {
+    NSInteger numberOfRowsInSection = [self.tableView numberOfRowsInSection:indexPath.section];
+    if (indexPath.section >= [self.tableView numberOfSections] ||
+        indexPath.row >= numberOfRowsInSection) {
+        NSLog(@"mopub-ios-sdk: MPTableViewAdPlacer: adPlacer:didLoadAdAtIndexPath: Attempted to insert row %@ in section %@ when number of sections is %@ and number of rows in section is %@", @(indexPath.row), @(indexPath.section), @(self.tableView.numberOfSections), @(numberOfRowsInSection));
+        return;
+    }
     BOOL originalAnimationsEnabled = [UIView areAnimationsEnabled];
     //We only want to enable animations if the index path is before or within our visible cells
     BOOL animationsEnabled = ([(NSIndexPath *)[self.tableView.indexPathsForVisibleRows lastObject] compare:indexPath] != NSOrderedAscending) && originalAnimationsEnabled;
@@ -117,6 +123,19 @@ static NSString * const kTableViewAdPlacerReuseIdentifier = @"MPTableViewAdPlace
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didRemoveAdsAtIndexPaths:(NSArray *)indexPaths
 {
+    for (const id obj in indexPaths) {
+        if (![obj isKindOfClass:[NSIndexPath class]]) {
+            return;
+        }
+        NSIndexPath *indexPath = obj;
+        NSInteger numberOfRowsInSection = [self.tableView numberOfRowsInSection:indexPath.section];
+        if (indexPath.section >= self.tableView.numberOfSections ||
+            indexPath.row >= numberOfRowsInSection) {
+            NSLog(@"mopub-ios-sdk: MPTableViewAdPlacer: adPlacer:didRemoveAdsAtIndexPath: IndexPaths: %@ Attempted to delete row %@ in section %@ when number of sections is %@ and number of rows in section is %@", indexPaths, @(indexPath.row), @(indexPath.section), @(self.tableView.numberOfSections), @(numberOfRowsInSection));
+            return;
+        }
+    }
+    
     BOOL originalAnimationsEnabled = [UIView areAnimationsEnabled];
     [UIView setAnimationsEnabled:NO];
     [self.tableView mp_beginUpdates];

--- a/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
@@ -105,7 +105,7 @@ static NSString * const kTableViewAdPlacerReuseIdentifier = @"MPTableViewAdPlace
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didLoadAdAtIndexPath:(NSIndexPath *)indexPath
 {
     NSInteger numberOfRowsInSection = [self.tableView numberOfRowsInSection:indexPath.section];
-    if (indexPath.section >= [self.tableView numberOfSections] ||
+    if (indexPath.section >= self.tableView.numberOfSections ||
         indexPath.row >= numberOfRowsInSection) {
         NSLog(@"mopub-ios-sdk: MPTableViewAdPlacer: adPlacer:didLoadAdAtIndexPath: Attempted to insert row %@ in section %@ when number of sections is %@ and number of rows in section is %@", @(indexPath.row), @(indexPath.section), @(self.tableView.numberOfSections), @(numberOfRowsInSection));
         return;

--- a/mopub-ios-sdk.podspec.json
+++ b/mopub-ios-sdk.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "mopub-ios-sdk",
-  "version": "4.5.1",
+  "version": "4.7.0",
   "summary": "The Official MoPub Client SDK allows developers to easily monetize their apps by showing banner, interstitial, and native ads.",
   "description": "                    MoPub is a hosted ad serving solution built specifically for mobile publishers.\n                    Grow your mobile advertising business with powerful ad management, optimization \n                    and reporting capabilities, and earn revenue by connecting to the world's largest \n                    mobile ad exchange. \n\n                    To learn more or sign up for an account, go to http://www.mopub.com. \n",
   "homepage": "https://github.com/mopub/mopub-ios-sdk",
@@ -16,8 +16,8 @@
     "ios": "6.0"
   },
   "source": {
-    "git": "https://github.com/mopub/mopub-ios-sdk.git",
-    "tag": "4.5.1"
+    "git": "https://github.com/Wattpad/mopub-ios-sdk.git",
+    "tag": "4.7.0"
   },
   "frameworks": [
     "CoreGraphics",


### PR DESCRIPTION
https://wattpad.atlassian.net/browse/IOS-7025

This should prevent the crash. There must be some case where the ad placer datasource and internal tableview datasource are not synced, but I haven't found the root cause yet. 

https://twittercommunity.com/t/crash-when-native-adverts-are-added-to-tableview/64614/3
https://twittercommunity.com/t/crash-when-load-native-ads/62946
