### PR TITLE
Make sure vc are properly deallocated after dismiss

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdDestinationDisplayAgent.m
+++ b/MoPubSDK/Internal/Common/MPAdDestinationDisplayAgent.m
@@ -310,6 +310,10 @@ static NSString * const kDisplayAgentErrorDomain = @"com.mopub.displayagent";
 {
     self.isLoadingDestination = NO;
     [self hideModalAndNotifyDelegate];
+    // Added by Elton: make sure vc is properly deallocated after dismiss
+    if (viewController == self.storeKitController) {
+        self.storeKitController = nil;
+    }
 }
 
 #pragma mark - <MPAdBrowserControllerDelegate>
@@ -318,6 +322,10 @@ static NSString * const kDisplayAgentErrorDomain = @"com.mopub.displayagent";
 {
     self.isLoadingDestination = NO;
     [self hideModalAndNotifyDelegate];
+    // Added by Elton: make sure vc is properly deallocated after dismiss
+    if (browserController == self.browserController) {
+        self.browserController = nil;
+    }
 }
 
 - (MPAdConfiguration *)adConfiguration


### PR DESCRIPTION
As the vc has a strong pointer by MPAdDestinationDisplayAgent.m, when it is dimissed, its memory is not deallocated until next vc is shown because MPAdDestinationDisplayAgent.m still hold it