### PR TITLE
Added methods so delegate of MPAdView can receive event when impression is registered

### DIFF
--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -395,6 +395,10 @@
     if (self.onscreenAdapter == adapter && [self shouldScheduleTimerOnImpressionDisplay]) {
         [self scheduleRefreshTimer];
     }
+    // Added by Elton: inform delegate when impression is tracked
+    if ([self.delegate respondsToSelector:@selector(adDidRegisterImpression:)]) {
+        [self.delegate managerDidTrackImpressionForAd:ad];
+    }
 }
 
 - (void)userActionWillBeginForAdapter:(MPBaseBannerAdapter *)adapter

--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -396,7 +396,7 @@
         [self scheduleRefreshTimer];
     }
     // Added by Elton: inform delegate when impression is tracked
-    if ([self.delegate respondsToSelector:@selector(adDidRegisterImpression:)]) {
+    if ([self.delegate respondsToSelector:@selector(managerDidTrackImpressionForAd:)]) {
         [self.delegate managerDidTrackImpressionForAd:ad];
     }
 }

--- a/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
@@ -24,6 +24,8 @@
 
 - (void)managerDidLoadAd:(UIView *)ad;
 - (void)managerDidFailToLoadAd;
+// Added by Elton: inform delegate when impression is tracked
+- (void)managerDidTrackImpressionForAd:(UIView *)ad;
 - (void)userActionWillBegin;
 - (void)userActionDidFinish;
 - (void)userWillLeaveApplication;

--- a/MoPubSDK/MPAdView.h
+++ b/MoPubSDK/MPAdView.h
@@ -297,4 +297,12 @@ typedef enum
  */
 - (void)willLeaveApplicationFromAd:(MPAdView *)view;
 
+/**
+ * Added by Elton:
+ * Sent when native ad has tracked/registred an impression
+ *
+ * @param nativeAd The native ad sending the message.
+ */
+- (void)didTrackImpression:(MPAdView *)view;
+
 @end

--- a/MoPubSDK/MPAdView.m
+++ b/MoPubSDK/MPAdView.m
@@ -190,4 +190,11 @@
     }
 }
 
+// Added by Elton: inform delegate when impression is tracked
+- (void)managerDidTrackImpressionForAd:(UIView *)ad {
+    if ([self.delegate respondsToSelector:@selector(didRegisterImpression:)]) {
+        [self.delegate didTrackImpression:self];
+    }
+}
+
 @end

--- a/MoPubSDK/MPAdView.m
+++ b/MoPubSDK/MPAdView.m
@@ -192,7 +192,7 @@
 
 // Added by Elton: inform delegate when impression is tracked
 - (void)managerDidTrackImpressionForAd:(UIView *)ad {
-    if ([self.delegate respondsToSelector:@selector(didRegisterImpression:)]) {
+    if ([self.delegate respondsToSelector:@selector(didTrackImpression:)]) {
         [self.delegate didTrackImpression:self];
     }
 }


### PR DESCRIPTION
@raxxpack No business logic change, just a way to help us track impression (will take effect when client side code change is introduced)